### PR TITLE
fix broken doc links

### DIFF
--- a/.github/contributing/engine_style_guide.md
+++ b/.github/contributing/engine_style_guide.md
@@ -1,6 +1,6 @@
 # Style guide: Engine
 
-For more advice on contributing to the engine, see the [relevant section](CONTRIBUTING.md#contributing-your-own-ideas) of CONTRIBUTING.md.
+For more advice on contributing to the engine, see the [relevant section](../../CONTRIBUTING.md#Contributing-your-own-ideas) of CONTRIBUTING.md.
 
 1. Prefer granular imports over glob imports of `bevy::prelude::*` and `bevy::sub_crate::*`.
 2. Use a consistent comment style:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ Examples in Bevy should be:
 
 When you add a new example, be sure to update `examples/README.md` with the new example and add it to the root `Cargo.toml` file.
 Use a generous sprinkling of keywords in your description: these are commonly used to search for a specific example.
-See the [example style guide](.github/contributing/example-style-guide.md) to help make sure the style of your example matches what we're already using.
+See the [example style guide](.github/contributing/example_style_guide.md) to help make sure the style of your example matches what we're already using.
 
 More complex demonstrations of functionality are also welcome, but for now belong in community tutorials or template games.
 
@@ -258,7 +258,7 @@ If you end up adding a new official Bevy crate to the `bevy` repo:
 When contributing, please:
 
 * try to loosely follow the workflow in [*How we work together*](https://github.com/bevy-engine/bevy/blob/main/CONTRIBUTING.md#how-we-work-together)
-* consult the [style guide](.github/contributing/engine-style-guide.md) to help keep our code base tidy
+* consult the [style guide](.github/contributing/engine_style_guide.md) to help keep our code base tidy
 * explain what you're doing and why
 * document new code with doc comments
 * include clear, simple tests


### PR DESCRIPTION
Here are the link fixes that we're complaining on CI. 
And I reverted two commits which removed links in `*_sytle_guide.md`