### PR TITLE
Tiny cosmetic change

### DIFF
--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -69,8 +69,6 @@ impl<T: Inputlike> Default for Input<T> {
 }
 
 impl<T: Inputlike> Input<T>
-where
-    T: Copy + Eq + Hash,
 {
     /// Register a press for input `input`.
     #[inline]


### PR DESCRIPTION
I know that has no effect on what so ever but it bothered me when reading it so hears a pull request.

# Objective

- Input is generic over all T that implement Inputlike but in the impl block there's an additional check for T to implement Copy + Eq + Hash which is a strict subset of Inputlike

## Solution

- Remove the where condition
