### PR TITLE
Fix main thread executor

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -150,13 +150,16 @@ impl SystemExecutor for MultiThreadedExecutor {
             }
         }
 
+        let thread_executor = world
+            .get_resource::<MainThreadExecutor>()
+            .map(|e| e.0.clone());
+        let thread_executor = thread_executor.as_deref();
+
         let world = SyncUnsafeCell::from_mut(world);
         let SyncUnsafeSchedule {
             systems,
             mut conditions,
         } = SyncUnsafeSchedule::new(schedule);
-
-        let thread_executor = world.get_resource::<MainThreadExecutor>().map(|e| &*e.0);
 
         ComputeTaskPool::init(TaskPool::default).scope_with_executor(
             false,


### PR DESCRIPTION
# Objective

- last change wasn't compiling correctly. This should fix that.
- I suspect the version in executor_parallel is actually unsound if someone drops the MainThreadExecutor resource from the world. The important bit in this PR is that we're cloning the Arc<ThreadExecutor> onto the stack. The SyncUnsafeCell<World> is doing it's job.