### PR TITLE
fix default_schedule_label lookup

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -339,7 +339,7 @@ impl App {
     pub fn add_system<P>(&mut self, system: impl IntoSystemConfig<P>) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
 
-        if let Some(default_schedule) = schedules.get_mut(&self.default_schedule_label) {
+        if let Some(default_schedule) = schedules.get_mut(&*self.default_schedule_label) {
             default_schedule.add_system(system);
         } else {
             let schedule_label = &self.default_schedule_label;
@@ -367,7 +367,7 @@ impl App {
     pub fn add_systems<P>(&mut self, systems: impl IntoSystemConfigs<P>) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
 
-        if let Some(default_schedule) = schedules.get_mut(&self.default_schedule_label) {
+        if let Some(default_schedule) = schedules.get_mut(&*self.default_schedule_label) {
             default_schedule.add_systems(systems);
         } else {
             let schedule_label = &self.default_schedule_label;


### PR DESCRIPTION
# Objective

`add_system` panics with `Default schedule {schedule_label:?} does not exist`.

```rust
        if let Some(default_schedule) = schedules.get_mut(&self.default_schedule_label) {
```
was always `None`.

# Fix

```rust
        if let Some(default_schedule) = schedules.get_mut(&*self.default_schedule_label) {
```

I don't know why `&Box<dyn ScheduleLabel>` implements `ScheduleLabel` but this seems like a big footgun.