### PR TITLE
Stage-yeet patch

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -168,7 +168,6 @@ impl Default for App {
         let mut app = App::empty();
         #[cfg(feature = "bevy_reflect")]
         app.init_resource::<AppTypeRegistry>();
-        app.init_resource::<Schedules>();
 
         app.add_default_schedules();
         app.add_default_sets();
@@ -197,8 +196,10 @@ impl App {
     ///
     /// This constructor should be used if you wish to provide custom scheduling, exit handling, cleanup, etc.
     pub fn empty() -> App {
+        let mut world = World::new();
+        world.init_resource::<Schedules>();
         Self {
-            world: Default::default(),
+            world,
             runner: Box::new(run_once),
             sub_apps: HashMap::default(),
             plugin_registry: Vec::default(),

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -143,7 +143,7 @@ impl SubApp {
     pub fn run(&mut self) {
         self.app
             .world
-            .run_schedule(&self.app.default_schedule_label);
+            .run_schedule(&*self.app.outer_schedule_label);
         self.app.world.clear_trackers();
     }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -459,6 +459,16 @@ impl App {
         self.add_systems_to_schedule(systems, CoreSchedule::Startup)
     }
 
+    /// Configures a system set in the default schedule, adding it if it does not exist.
+    pub fn configure_set(&mut self, set: impl IntoSystemSetConfig) -> &mut Self {
+        self.world
+            .resource_mut::<Schedules>()
+            .get_mut(&*self.default_schedule_label)
+            .unwrap()
+            .configure_set(set);
+        self
+    }
+
     /// Adds standardized schedules and labels to an [`App`].
     ///
     /// Adding these schedules is necessary to make almost all core engine features work.

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -107,11 +107,9 @@ impl Plugin for AssetPlugin {
 
         app.register_type::<HandleId>();
 
-        let main_schedule = app.schedule_mut(&CoreSchedule::Main).unwrap();
-
-        main_schedule
-            .configure_set(AssetSet::LoadAssets.before(CoreSet::PreUpdate))
-            .configure_set(AssetSet::AssetEvents.after(CoreSet::PostUpdate))
+        app
+            .configure_set(AssetSet::LoadAssets.no_default_set().before(CoreSet::PreUpdate))
+            .configure_set(AssetSet::AssetEvents.no_default_set().after(CoreSet::PostUpdate))
             .add_system(asset_server::free_unused_assets_system.in_set(CoreSet::PreUpdate));
 
         #[cfg(all(

--- a/crates/bevy_ecs/src/scheduling/config.rs
+++ b/crates/bevy_ecs/src/scheduling/config.rs
@@ -1,5 +1,4 @@
 use bevy_ecs_macros::all_tuples;
-use bevy_utils::default;
 
 use crate::{
     scheduling::{
@@ -29,11 +28,7 @@ impl SystemSetConfig {
 
         Self {
             set,
-            graph_info: GraphInfo {
-                sets: Vec::new(),
-                dependencies: Vec::new(),
-                ambiguous_with: default(),
-            },
+            graph_info: GraphInfo::default(),
             conditions: Vec::new(),
         }
     }
@@ -54,8 +49,7 @@ impl SystemConfig {
             system,
             graph_info: GraphInfo {
                 sets,
-                dependencies: Vec::new(),
-                ambiguous_with: default(),
+                ..Default::default()
             },
             conditions: Vec::new(),
         }
@@ -94,6 +88,8 @@ pub trait IntoSystemSetConfig: sealed::IntoSystemSetConfig {
     fn into_config(self) -> SystemSetConfig;
     /// Add to the provided `set`.
     fn in_set(self, set: impl SystemSet) -> SystemSetConfig;
+    /// Don't add this set to the schedules's default set.
+    fn no_default_set(self) -> SystemSetConfig;
     /// Run before all systems in `set`.
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemSetConfig;
     /// Run after all systems in `set`.
@@ -123,6 +119,10 @@ where
 
     fn in_set(self, set: impl SystemSet) -> SystemSetConfig {
         self.into_config().in_set(set)
+    }
+
+    fn no_default_set(self) -> SystemSetConfig {
+        self.into_config().no_default_set()
     }
 
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemSetConfig {
@@ -157,6 +157,10 @@ impl IntoSystemSetConfig for BoxedSystemSet {
 
     fn in_set(self, set: impl SystemSet) -> SystemSetConfig {
         self.into_config().in_set(set)
+    }
+
+    fn no_default_set(self) -> SystemSetConfig {
+        self.into_config().no_default_set()
     }
 
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemSetConfig {
@@ -195,6 +199,11 @@ impl IntoSystemSetConfig for SystemSetConfig {
             "adding arbitrary systems to a system type set is not allowed"
         );
         self.graph_info.sets.push(Box::new(set));
+        self
+    }
+
+    fn no_default_set(mut self) -> SystemSetConfig {
+        self.graph_info.no_default_set = true;
         self
     }
 
@@ -244,6 +253,8 @@ pub trait IntoSystemConfig<Params>: sealed::IntoSystemConfig<Params> {
     fn into_config(self) -> SystemConfig;
     /// Add to `set` membership.
     fn in_set(self, set: impl SystemSet) -> SystemConfig;
+    /// Don't add this system to the schedules's default set.
+    fn no_default_set(self) -> SystemConfig;
     /// Run before all systems in `set`.
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfig;
     /// Run after all systems in `set`.
@@ -273,6 +284,10 @@ where
 
     fn in_set(self, set: impl SystemSet) -> SystemConfig {
         self.into_config().in_set(set)
+    }
+
+    fn no_default_set(self) -> SystemConfig {
+        self.into_config().no_default_set()
     }
 
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfig {
@@ -307,6 +322,10 @@ impl IntoSystemConfig<()> for BoxedSystem<(), ()> {
 
     fn in_set(self, set: impl SystemSet) -> SystemConfig {
         self.into_config().in_set(set)
+    }
+
+    fn no_default_set(self) -> SystemConfig {
+        self.into_config().no_default_set()
     }
 
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemConfig {
@@ -345,6 +364,11 @@ impl IntoSystemConfig<()> for SystemConfig {
             "adding arbitrary systems to a system type set is not allowed"
         );
         self.graph_info.sets.push(Box::new(set));
+        self
+    }
+
+    fn no_default_set(mut self) -> SystemConfig {
+        self.graph_info.no_default_set = true;
         self
     }
 

--- a/crates/bevy_ecs/src/scheduling/config.rs
+++ b/crates/bevy_ecs/src/scheduling/config.rs
@@ -203,7 +203,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
     }
 
     fn no_default_set(mut self) -> SystemSetConfig {
-        self.graph_info.no_default_set = true;
+        self.graph_info.add_default_set = false;
         self
     }
 
@@ -368,7 +368,7 @@ impl IntoSystemConfig<()> for SystemConfig {
     }
 
     fn no_default_set(mut self) -> SystemConfig {
-        self.graph_info.no_default_set = true;
+        self.graph_info.add_default_set = false;
         self
     }
 

--- a/crates/bevy_ecs/src/scheduling/graph_utils.rs
+++ b/crates/bevy_ecs/src/scheduling/graph_utils.rs
@@ -67,11 +67,12 @@ pub(crate) enum Ambiguity {
     IgnoreAll,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct GraphInfo {
     pub(crate) sets: Vec<BoxedSystemSet>,
     pub(crate) dependencies: Vec<Dependency>,
     pub(crate) ambiguous_with: Ambiguity,
+    pub(crate) no_default_set: bool,
 }
 
 /// Converts 2D row-major pair of indices into a 1D array index.

--- a/crates/bevy_ecs/src/scheduling/graph_utils.rs
+++ b/crates/bevy_ecs/src/scheduling/graph_utils.rs
@@ -67,12 +67,23 @@ pub(crate) enum Ambiguity {
     IgnoreAll,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub(crate) struct GraphInfo {
     pub(crate) sets: Vec<BoxedSystemSet>,
     pub(crate) dependencies: Vec<Dependency>,
     pub(crate) ambiguous_with: Ambiguity,
-    pub(crate) no_default_set: bool,
+    pub(crate) add_default_set: bool,
+}
+
+impl Default for GraphInfo {
+    fn default() -> Self {
+        GraphInfo {
+            sets: Vec::new(),
+            dependencies: Vec::new(),
+            ambiguous_with: Ambiguity::default(),
+            add_default_set: true,
+        }
+    }
 }
 
 /// Converts 2D row-major pair of indices into a 1D array index.

--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -374,7 +374,7 @@ impl ScheduleGraph {
         let id = NodeId::System(self.systems.len());
 
         if let [single_set] = graph_info.sets.as_slice() {
-            if single_set.is_system_type() && !graph_info.no_default_set {
+            if single_set.is_system_type() && graph_info.add_default_set {
                 if let Some(default) = self.default_set.as_ref() {
                     graph_info.sets.push(default.dyn_clone());
                 }
@@ -434,7 +434,7 @@ impl ScheduleGraph {
 
         // a system set can be configured multiple times, so this "default check"
         // should only happen the first time `configure_set` is called on it
-        if !already_configured && graph_info.sets.is_empty() && !graph_info.no_default_set {
+        if !already_configured && graph_info.sets.is_empty() && graph_info.add_default_set {
             if let Some(default) = self.default_set.as_ref() {
                 info!("adding system set `{:?}` to default: `{:?}`", set, default);
                 graph_info.sets.push(default.dyn_clone());

--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -374,7 +374,7 @@ impl ScheduleGraph {
         let id = NodeId::System(self.systems.len());
 
         if let [single_set] = graph_info.sets.as_slice() {
-            if single_set.is_system_type() {
+            if single_set.is_system_type() && !graph_info.no_default_set {
                 if let Some(default) = self.default_set.as_ref() {
                     graph_info.sets.push(default.dyn_clone());
                 }
@@ -434,7 +434,7 @@ impl ScheduleGraph {
 
         // a system set can be configured multiple times, so this "default check"
         // should only happen the first time `configure_set` is called on it
-        if !already_configured && graph_info.sets.is_empty() {
+        if !already_configured && graph_info.sets.is_empty() && !graph_info.no_default_set {
             if let Some(default) = self.default_set.as_ref() {
                 info!("adding system set `{:?}` to default: `{:?}`", set, default);
                 graph_info.sets.push(default.dyn_clone());
@@ -524,6 +524,7 @@ impl ScheduleGraph {
             sets,
             dependencies,
             ambiguous_with,
+            ..
         } = graph_info;
 
         if !self.hierarchy.graph.contains_node(id) {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -222,7 +222,6 @@ impl Plugin for RenderPlugin {
             let asset_server = app.world.resource::<AssetServer>().clone();
 
             let mut render_app = App::empty();
-            render_app.init_resource::<Schedules>();
             let mut render_schedule = RenderSet::base_schedule();
 
             // Prepare the schedule which extracts data from the main world to the render world

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -26,7 +26,6 @@
 
 use bevy::{
     app::{AppExit, ScheduleRunnerPlugin, ScheduleRunnerSettings},
-    ecs::scheduling::ReportExecutionOrderAmbiguities,
     log::LogPlugin,
     prelude::*,
     utils::Duration,
@@ -290,10 +289,10 @@ fn main() {
         // "before_round": new_player_system, new_round_system
         // "update": print_message_system, score_system
         // "after_round": score_check_system, game_over_system
-        .configure_set(MySet::BeforeRound.before(CoreSet::Update))
-        .configure_set(MySet::AfterRound.after(CoreSet::Update))
+        .configure_set(MySet::BeforeRound.no_default_set().before(CoreSet::Update))
+        .configure_set(MySet::AfterRound.no_default_set().after(CoreSet::Update))
         .add_system(new_round_system.in_set(MySet::BeforeRound))
-        .add_system(new_player_system.after(new_round_system.in_set(MySet::BeforeRound)))
+        .add_system(new_player_system.after(new_round_system).in_set(MySet::BeforeRound))
         .add_system(exclusive_player_system.in_set(MySet::BeforeRound))
         .add_system(score_check_system.in_set(MySet::AfterRound))
         .add_system(
@@ -307,7 +306,6 @@ fn main() {
         // Be aware that not everything reported by this checker is a potential problem, you'll have
         // to make that judgement yourself.
         .add_plugin(LogPlugin::default())
-        .init_resource::<ReportExecutionOrderAmbiguities>()
         // This call to run() starts the app we just built!
         .run();
 }


### PR DESCRIPTION
This time with descriptive commit messages!

`App::empty()` now adds the `Schedules` resource since it's pretty much required when using `App` 

I added `no_default_set()` to `IntoSystem(Set)Config`, but I'm not 100% sure if that makes sense yet. It's simple enough

Render Schedules aren't set up correctly yet (The SubApp is trying to run `CoresSchedule::Outer`) but now systems from `DefaultPlugins` are actually running!
Now were crashing on an assert about there being entities in the render world at the start of it's run.

~Btw the changes made to the `ScheduleLabel` derive are not compiling. I couldn't figure out a fix.~ nvm, it was a simple typo. Terrible error message tho :v