### PR TITLE
Fix schedule run

### DIFF
--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -42,7 +42,7 @@ impl Schedules {
     /// If the map already had an entry for `label`, `schedule` is inserted,
     /// and the old schedule is returned. Otherwise, `None` is returned.
     pub fn insert(&mut self, label: impl ScheduleLabel, schedule: Schedule) -> Option<Schedule> {
-        let label: Box<dyn ScheduleLabel> = Box::new(label);
+        let label = label.dyn_clone();
         if self.inner.contains_key(&label) {
             warn!("schedule with label {:?} already exists", label);
         }
@@ -1088,5 +1088,15 @@ impl ScheduleBuildSettings {
     pub fn with_hierarchy_detection(mut self, level: LogLevel) -> Self {
         self.hierarchy_detection = level;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let mut schedules = Schedules::new();
     }
 }


### PR DESCRIPTION
# Objective

- world.run_schedule was not working the second time it was called. I'm not 100% sure what was going wrong, but I think we were double boxing the label the second time we inserted it. This fixes things.