### PR TITLE
Migration tweaks

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -380,12 +380,12 @@ impl App {
     /// Adds a system to the provided [`Schedule`].
     pub fn add_system_to_schedule<P>(
         &mut self,
+        schedule_label: impl ScheduleLabel,
         system: impl IntoSystemConfig<P>,
-        schedule_label: &impl ScheduleLabel,
     ) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
 
-        if let Some(schedule) = schedules.get_mut(schedule_label) {
+        if let Some(schedule) = schedules.get_mut(&schedule_label) {
             schedule.add_system(system);
         } else {
             panic!("Provided schedule {schedule_label:?} does not exist.")
@@ -397,12 +397,12 @@ impl App {
     /// Adds a collection of system to the provided [`Schedule`].
     pub fn add_systems_to_schedule<P>(
         &mut self,
+        schedule_label: impl ScheduleLabel,
         systems: impl IntoSystemConfigs<P>,
-        schedule_label: &impl ScheduleLabel,
     ) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
 
-        if let Some(schedule) = schedules.get_mut(schedule_label) {
+        if let Some(schedule) = schedules.get_mut(&schedule_label) {
             schedule.add_systems(systems);
         } else {
             panic!("Provided schedule {schedule_label:?} does not exist.")
@@ -430,7 +430,7 @@ impl App {
     ///     .add_startup_system(my_startup_system);
     /// ```
     pub fn add_startup_system<P>(&mut self, system: impl IntoSystemConfig<P>) -> &mut Self {
-        self.add_system_to_schedule(system, &CoreSchedule::Startup)
+        self.add_system_to_schedule(CoreSchedule::Startup, system)
     }
 
     /// Adds a collection of systems to [`CoreSchedule::Startup`].
@@ -455,7 +455,7 @@ impl App {
     /// );
     /// ```
     pub fn add_startup_systems<P>(&mut self, systems: impl IntoSystemConfigs<P>) -> &mut Self {
-        self.add_systems_to_schedule(systems, &CoreSchedule::Startup)
+        self.add_systems_to_schedule(CoreSchedule::Startup, systems)
     }
 
     /// Configures a system set in the default schedule, adding it if it does not exist.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -141,7 +141,9 @@ pub struct SubApp {
 impl SubApp {
     /// Runs the `SubApp`'s default schedule.
     pub fn run(&mut self) {
-        self.app.world.run_schedule(&*self.app.outer_schedule_label);
+        self.app
+            .world
+            .run_schedule_ref(&*self.app.outer_schedule_label);
         self.app.world.clear_trackers();
     }
 
@@ -223,7 +225,7 @@ impl App {
         {
             #[cfg(feature = "trace")]
             let _bevy_frame_update_span = info_span!("main app").entered();
-            self.run_schedule(&*self.outer_schedule_label.dyn_clone());
+            self.world.run_schedule_ref(&*self.outer_schedule_label);
         }
         for (_label, sub_app) in self.sub_apps.iter_mut() {
             #[cfg(feature = "trace")]
@@ -299,7 +301,7 @@ impl App {
         self.init_resource::<NextState<S>>();
         self.add_system(apply_state_transition::<S>.in_set(CoreSet::StateTransitions));
 
-        let main_schedule = self.schedule_mut(&CoreSchedule::Main).unwrap();
+        let main_schedule = self.schedule_mut(CoreSchedule::Main).unwrap();
         for variant in S::variants() {
             main_schedule.configure_set(
                 OnUpdate(variant)
@@ -932,24 +934,24 @@ impl App {
     }
 
     /// Runs the [`Schedule`] with the provided `label` on the app's [`World`] a single time.
-    pub fn run_schedule(&mut self, label: &dyn ScheduleLabel) -> &mut Self {
+    pub fn run_schedule(&mut self, label: impl ScheduleLabel) -> &mut Self {
         self.world.run_schedule(label);
 
         self
     }
 
     /// Gets read-only access to the [`Schedule`] with the provided `label` if it exists.
-    pub fn schedule(&self, label: &impl ScheduleLabel) -> Option<&Schedule> {
+    pub fn schedule(&self, label: impl ScheduleLabel) -> Option<&Schedule> {
         let schedules = self.world.get_resource::<Schedules>()?;
-        schedules.get(label)
+        schedules.get(&label)
     }
 
     /// Gets read-write access to a [`Schedule`] with the provided `label` if it exists.
-    pub fn schedule_mut(&mut self, label: &impl ScheduleLabel) -> Option<&mut Schedule> {
+    pub fn schedule_mut(&mut self, label: impl ScheduleLabel) -> Option<&mut Schedule> {
         let schedules = self.world.get_resource_mut::<Schedules>()?;
         // We need to call .into_inner here to satisfy the borrow checker:
         // it can reason about reborrows using ordinary references but not the `Mut` smart pointer.
-        schedules.into_inner().get_mut(label)
+        schedules.into_inner().get_mut(&label)
     }
 
     /// Applies the function to the [`Schedule`] associated with `label`.

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -64,11 +64,11 @@ impl CoreSchedule {
     /// If this is the first time this system has been run, [`CoreSchedule::Startup`] will run before [`CoreSchedule::Main`].
     pub fn outer_loop(world: &mut World, mut run_at_least_once: Local<bool>) {
         if !*run_at_least_once {
-            world.run_schedule(&CoreSchedule::Startup);
+            world.run_schedule(CoreSchedule::Startup);
             *run_at_least_once = true;
         }
 
-        world.run_schedule(&CoreSchedule::Main);
+        world.run_schedule(CoreSchedule::Main);
     }
 
     /// Initializes a schedule for [`CoreSchedule::Outer`] that contains the [`outer_loop`] system.

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -2,7 +2,7 @@ use crate::{
     update_asset_storage_system, Asset, AssetLoader, AssetServer, AssetSet, Handle, HandleId,
     RefChange, ReflectAsset, ReflectHandle,
 };
-use bevy_app::{App, AppTypeRegistry, CoreSet};
+use bevy_app::{App, AppTypeRegistry};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect};
 use bevy_utils::HashMap;

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -51,9 +51,7 @@ impl Plugin for Core2dPlugin {
 
         render_app
             .init_resource::<DrawFunctions<Transparent2d>>()
-            .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule.add_system(extract_core_2d_camera_phases);
-            })
+            .add_system_to_schedule(ExtractSchedule, extract_core_2d_camera_phases)
             .add_system(sort_phase_system::<Transparent2d>.in_set(RenderSet::PhaseSort))
             .add_system(
                 batch_phase_system::<Transparent2d>

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -67,9 +67,7 @@ impl Plugin for Core3dPlugin {
             .init_resource::<DrawFunctions<Opaque3d>>()
             .init_resource::<DrawFunctions<AlphaMask3d>>()
             .init_resource::<DrawFunctions<Transparent3d>>()
-            .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule.add_system(extract_core_3d_camera_phases);
-            })
+            .add_system_to_schedule(ExtractSchedule, extract_core_3d_camera_phases)
             .add_system(prepare_core_3d_depth_textures.in_set(RenderSet::Prepare))
             .add_system(sort_phase_system::<Opaque3d>.in_set(RenderSet::PhaseSort))
             .add_system(sort_phase_system::<AlphaMask3d>.in_set(RenderSet::PhaseSort))

--- a/crates/bevy_ecs/src/scheduling/state.rs
+++ b/crates/bevy_ecs/src/scheduling/state.rs
@@ -97,7 +97,7 @@ pub fn apply_state_transition<S: States>(world: &mut World) {
     if world.resource::<NextState<S>>().0.is_some() {
         let entered_state = world.resource_mut::<NextState<S>>().0.take().unwrap();
         let exited_state = mem::replace(&mut world.resource_mut::<State<S>>().0, entered_state);
-        world.run_schedule(&OnExit(exited_state));
-        world.run_schedule(&OnEnter(entered_state));
+        world.run_schedule(OnExit(exited_state));
+        world.run_schedule(OnEnter(entered_state));
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1991,7 +1991,17 @@ impl World {
     /// and system state is cached.
     ///
     /// For simple testing use cases, call [`Schedule::run(world)`](Schedule::run) instead.
-    pub fn run_schedule(&mut self, label: &dyn ScheduleLabel) {
+    pub fn run_schedule(&mut self, label: impl ScheduleLabel) {
+        self.run_schedule_ref(&label)
+    }
+
+    /// Runs the [`Schedule`] associated with the `label` a single time.
+    ///
+    /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
+    /// and system state is cached.
+    ///
+    /// For simple testing use cases, call [`Schedule::run(world)`](Schedule::run) instead.
+    pub fn run_schedule_ref(&mut self, label: &dyn ScheduleLabel) {
         if let Some((extracted_label, mut schedule)) =
             self.resource_mut::<Schedules>().remove_entry(label)
         {

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -237,13 +237,13 @@ impl Plugin for PbrPlugin {
 
         // Extract the required data from the main world
         render_app
-            .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule
-                    .add_system(
-                        render::extract_clusters.in_set(RenderLightSystems::ExtractClusters),
-                    )
-                    .add_system(render::extract_lights.in_set(RenderLightSystems::ExtractLights));
-            })
+            .add_systems_to_schedule(
+                ExtractSchedule,
+                (
+                    render::extract_clusters.in_set(RenderLightSystems::ExtractClusters),
+                    render::extract_lights.in_set(RenderLightSystems::ExtractLights),
+                ),
+            )
             .add_system(
                 render::prepare_lights
                     .before(ViewSet::PrepareUniforms)

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -195,9 +195,7 @@ where
                 .init_resource::<ExtractedMaterials<M>>()
                 .init_resource::<RenderMaterials<M>>()
                 .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule.add_system(extract_materials::<M>);
-                })
+                .add_system_to_schedule(ExtractSchedule, extract_materials::<M>)
                 .add_system(
                     prepare_materials::<M>
                         .after(PrepareAssetLabel::PreAssetPrepare)

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -101,11 +101,7 @@ impl Plugin for MeshRenderPlugin {
             render_app
                 .init_resource::<MeshPipeline>()
                 .init_resource::<SkinnedMeshUniform>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule
-                        .add_system(extract_meshes)
-                        .add_system(extract_skinned_meshes);
-                })
+                .add_systems_to_schedule(ExtractSchedule, (extract_meshes, extract_skinned_meshes))
                 .add_system(prepare_skinned_meshes.in_set(RenderSet::Prepare))
                 .add_system(queue_mesh_bind_group.in_set(RenderSet::Queue))
                 .add_system(queue_mesh_view_bind_groups.in_set(RenderSet::Queue));

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -46,9 +46,7 @@ impl Plugin for WireframePlugin {
                 .add_render_command::<Opaque3d, DrawWireframes>()
                 .init_resource::<WireframePipeline>()
                 .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule.add_system(extract_wireframes);
-                })
+                .add_system_to_schedule(ExtractSchedule, extract_wireframes)
                 .add_system(queue_wireframes.in_set(RenderSet::Queue));
         }
     }

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -27,10 +27,7 @@ impl Plugin for CameraPlugin {
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule.add_system(extract_cameras);
-            });
-
+            render_app.add_system_to_schedule(ExtractSchedule, extract_cameras);
             let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
             let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
             render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -177,13 +177,11 @@ impl<C, F> ExtractComponentPlugin<C, F> {
 impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.edit_schedule(&ExtractSchedule, |extract_schedule| {
-                if self.only_extract_visible {
-                    extract_schedule.add_system(extract_visible_components::<C>);
-                } else {
-                    extract_schedule.add_system(extract_components::<C>);
-                }
-            });
+            if self.only_extract_visible {
+                render_app.add_system_to_schedule(ExtractSchedule, extract_visible_components::<C>);
+            } else {
+                render_app.add_system_to_schedule(ExtractSchedule, extract_components::<C>);
+            }
         }
     }
 }

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -33,9 +33,7 @@ impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {
 impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule.add_system(extract_resource::<R>);
-            });
+            render_app.add_system_to_schedule(ExtractSchedule, extract_resource::<R>);
         }
     }
 }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -20,11 +20,7 @@ impl Plugin for GlobalsPlugin {
             render_app
                 .init_resource::<GlobalsBuffer>()
                 .init_resource::<Time>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule
-                        .add_system(extract_frame_count)
-                        .add_system(extract_time);
-                })
+                .add_systems_to_schedule(ExtractSchedule, (extract_frame_count, extract_time))
                 .add_system(prepare_globals_buffer.in_set(RenderSet::Prepare));
         }
     }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -247,7 +247,7 @@ impl Plugin for RenderPlugin {
 
             let mut outer_schedule = Schedule::new();
             outer_schedule.add_system(|world: &mut World| {
-                world.run_schedule(&CoreSchedule::Main);
+                world.run_schedule(CoreSchedule::Main);
             });
 
             render_app
@@ -332,7 +332,7 @@ fn extract(main_world: &mut World, render_app: &mut App) {
     let inserted_world = std::mem::replace(main_world, scratch_world.0);
     render_app.world.insert_resource(MainWorld(inserted_world));
 
-    render_app.run_schedule(&ExtractSchedule);
+    render_app.run_schedule(ExtractSchedule);
 
     // move the app world back, as if nothing happened.
     let inserted_world = render_app.world.remove_resource::<MainWorld>().unwrap();

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -220,12 +220,9 @@ impl Plugin for RenderPlugin {
             let mut render_schedule = RenderSet::base_schedule();
 
             // Prepare the schedule which extracts data from the main world to the render world
-            render_app.init_schedule(ExtractSchedule).edit_schedule(
-                &ExtractSchedule,
-                |extract_schedule| {
-                    extract_schedule.add_system(PipelineCache::extract_shaders);
-                },
-            );
+            render_app
+                .init_schedule(ExtractSchedule)
+                .add_system_to_schedule(ExtractSchedule, PipelineCache::extract_shaders);
 
             // TODO: look closer at the next 2 lines. something looks weird here
             // Get the ComponentId for MainWorld. This does technically 'waste' a `WorldId`, but that's probably fine

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -75,7 +75,7 @@ impl Plugin for PipelinedRenderingPlugin {
         sub_app.init_schedule(CoreSchedule::Main);
         let mut outer_schedule = Schedule::new();
         outer_schedule.add_system(|world: &mut World| {
-            world.run_schedule(&CoreSchedule::Main);
+            world.run_schedule(CoreSchedule::Main);
         });
         sub_app.add_schedule(CoreSchedule::Outer, outer_schedule);
         app.add_sub_app(RenderExtractApp, sub_app, update_rendering);

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -95,9 +95,7 @@ impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
                 .init_resource::<ExtractedAssets<A>>()
                 .init_resource::<RenderAssets<A>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule.add_system(extract_render_asset::<A>);
-                })
+                .add_system_to_schedule(ExtractSchedule, extract_render_asset::<A>)
                 .add_system(prepare_asset_system.in_set(RenderSet::Prepare));
         }
     }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -30,9 +30,7 @@ impl Plugin for WindowRenderPlugin {
                 .init_resource::<ExtractedWindows>()
                 .init_resource::<WindowSurfaces>()
                 .init_non_send_resource::<NonSendMarker>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule.add_system(extract_windows);
-                })
+                .add_system_to_schedule(ExtractSchedule, extract_windows)
                 .add_system(
                     prepare_windows
                         .in_set(WindowSystem::Prepare)

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -70,11 +70,13 @@ impl Plugin for SpritePlugin {
                 .init_resource::<ExtractedSprites>()
                 .init_resource::<SpriteAssetEvents>()
                 .add_render_command::<Transparent2d, DrawSprite>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule
-                        .add_system(extract_sprites.in_set(SpriteSystem::ExtractSprites))
-                        .add_system(extract_sprite_events);
-                })
+                .add_systems_to_schedule(
+                    ExtractSchedule,
+                    (
+                        extract_sprites.in_set(SpriteSystem::ExtractSprites),
+                        extract_sprite_events,
+                    ),
+                )
                 .add_system(queue_sprites.in_set(RenderSet::Queue));
         };
     }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -158,9 +158,7 @@ where
                 .init_resource::<ExtractedMaterials2d<M>>()
                 .init_resource::<RenderMaterials2d<M>>()
                 .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule.add_system(extract_materials_2d::<M>);
-                })
+                .add_system_to_schedule(ExtractSchedule, extract_materials_2d::<M>)
                 .add_system(
                     prepare_materials_2d::<M>
                         .after(PrepareAssetLabel::PreAssetPrepare)

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -102,9 +102,7 @@ impl Plugin for Mesh2dRenderPlugin {
             render_app
                 .init_resource::<Mesh2dPipeline>()
                 .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
-                .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                    extract_schedule.add_system(extract_mesh2d);
-                })
+                .add_system_to_schedule(ExtractSchedule, extract_mesh2d)
                 .add_system(queue_mesh2d_bind_group.in_set(RenderSet::Queue))
                 .add_system(queue_mesh2d_view_bind_groups.in_set(RenderSet::Queue));
         }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -92,10 +92,10 @@ impl Plugin for TextPlugin {
             );
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule
-                    .add_system(extract_text2d_sprite.after(SpriteSystem::ExtractSprites));
-            });
+            render_app.add_system_to_schedule(
+                ExtractSchedule,
+                extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
+            );
         }
     }
 }

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -112,7 +112,7 @@ pub fn apply_fixed_timestep(world: &mut World) {
         let mut check_again = true;
         while check_again {
             if fixed_time.expend().is_ok() {
-                world.run_schedule(&CoreSchedule::FixedTimestep);
+                world.run_schedule(CoreSchedule::FixedTimestep);
             } else {
                 check_again = false;
             }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -72,13 +72,15 @@ pub fn build_ui_render(app: &mut App) {
         .init_resource::<ExtractedUiNodes>()
         .init_resource::<DrawFunctions<TransparentUi>>()
         .add_render_command::<TransparentUi, DrawUi>()
-        .edit_schedule(&ExtractSchedule, |extract_schedule| {
-            extract_schedule
-                .add_system(extract_default_ui_camera_view::<Camera2d>)
-                .add_system(extract_default_ui_camera_view::<Camera3d>)
-                .add_system(extract_uinodes.in_set(RenderUiSystem::ExtractNode))
-                .add_system(extract_text_uinodes.after(RenderUiSystem::ExtractNode));
-        })
+        .add_systems_to_schedule(
+            ExtractSchedule,
+            (
+                extract_default_ui_camera_view::<Camera2d>,
+                extract_default_ui_camera_view::<Camera3d>,
+                extract_uinodes.in_set(RenderUiSystem::ExtractNode),
+                extract_text_uinodes.after(RenderUiSystem::ExtractNode),
+            ),
+        )
         .add_system(prepare_uinodes.in_set(RenderSet::Prepare))
         .add_system(queue_uinodes.in_set(RenderSet::Queue))
         .add_system(sort_phase_system::<TransparentUi>.in_set(RenderSet::PhaseSort));

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -282,9 +282,7 @@ impl Plugin for ColoredMesh2dPlugin {
             .add_render_command::<Transparent2d, DrawColoredMesh2d>()
             .init_resource::<ColoredMesh2dPipeline>()
             .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
-            .edit_schedule(&ExtractSchedule, |extract_schedule| {
-                extract_schedule.add_system(extract_colored_mesh2d);
-            })
+            .add_system_to_schedule(ExtractSchedule, extract_colored_mesh2d)
             .add_system(queue_colored_mesh2d.in_set(RenderSet::Queue));
     }
 }

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -4,7 +4,6 @@ use bevy::{
     prelude::*,
     sprite::collide_aabb::{collide, Collision},
     sprite::MaterialMesh2dBundle,
-    time::FixedTimestep,
 };
 
 // Defines the amount of time that should elapse between each physics step.

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -59,13 +59,13 @@ fn main() {
         .add_event::<CollisionEvent>()
         // Add our gameplay simulation systems to the fixed timestep schedule
         .add_systems_to_schedule(
+            CoreSchedule::FixedTimestep,
             (
                 check_for_collisions,
                 move_paddle.before(check_for_collisions),
                 apply_velocity.before(check_for_collisions),
                 play_collision_sound.after(check_for_collisions),
             ),
-            &CoreSchedule::FixedTimestep,
         )
         // Configure how frequently our gameplay systems are run
         .insert_resource(FixedTime::new_from_secs(TIME_STEP))


### PR DESCRIPTION
* Remove references from schedule label apis where possible: this makes them easier to use / more in line with our other label apis.
* Specify the label first in `add_system_to_schedule`.  That way it doesn't move around each time we add a new system. It is more diff-friendly and follows the general pattern we use elsewhere in rust: x.do_something(key,value)
* Migrate from `edit_schedule` instances to `add_system_to_schedule`. It is vastly superior for these use cases.