### PR TITLE
stageless: better system set inheritance

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -56,21 +56,14 @@ impl Plugin for InputPlugin {
             .add_event::<KeyboardInput>()
             .init_resource::<Input<KeyCode>>()
             .init_resource::<Input<ScanCode>>()
-            .add_system(
-                keyboard_input_system
-                    .in_set(InputSystem)
-                    .in_set(CoreSet::PreUpdate),
-            )
+            .add_system(keyboard_input_system.in_set(InputSystem))
             // mouse
             .add_event::<MouseButtonInput>()
             .add_event::<MouseMotion>()
             .add_event::<MouseWheel>()
             .init_resource::<Input<MouseButton>>()
-            .add_system(
-                mouse_button_input_system
-                    .in_set(InputSystem)
-                    .in_set(CoreSet::PreUpdate),
-            )
+            .configure_set(InputSystem.in_set(CoreSet::PreUpdate))
+            .add_system(mouse_button_input_system.in_set(InputSystem))
             // gamepad
             .add_event::<GamepadConnectionEvent>()
             .add_event::<GamepadButtonChangedEvent>()
@@ -88,17 +81,12 @@ impl Plugin for InputPlugin {
                     gamepad_axis_event_system.after(gamepad_event_system),
                     gamepad_connection_system.after(gamepad_event_system),
                 )
-                    .in_set(InputSystem)
-                    .in_set(CoreSet::PreUpdate),
+                    .in_set(InputSystem),
             )
             // touch
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
-            .add_system(
-                touch_screen_input_system
-                    .in_set(InputSystem)
-                    .in_set(CoreSet::PreUpdate),
-            );
+            .add_system(touch_screen_input_system.in_set(InputSystem));
 
         // Register common types
         app.register_type::<ButtonState>();

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -169,16 +169,22 @@ impl Plugin for PbrPlugin {
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()
             .add_plugin(ExtractResourcePlugin::<AmbientLight>::default())
+            .configure_set(SimulationLightSystems::AddClusters.in_set(CoreSet::PostUpdate))
+            .configure_set(SimulationLightSystems::UpdateLightFrusta.in_set(CoreSet::PostUpdate))
+            .configure_set(
+                SimulationLightSystems::AssignLightsToClusters.in_set(CoreSet::PostUpdate),
+            )
+            .configure_set(SimulationLightSystems::UpdateLightFrusta.in_set(CoreSet::PostUpdate))
+            .configure_set(SimulationLightSystems::CheckLightVisibility.in_set(CoreSet::PostUpdate))
+            .configure_set(SimulationLightSystems::UpdateDirectionalLightCascades.in_set(CoreSet::PostUpdate))
             .add_system(
                 add_clusters
                     .in_set(SimulationLightSystems::AddClusters)
-                    .in_set(CoreSet::PostUpdate)
                     .before(assign_lights_to_clusters),
             )
             .add_system(
                 assign_lights_to_clusters
                     .in_set(SimulationLightSystems::AssignLightsToClusters)
-                    .in_set(CoreSet::PostUpdate)
                     .after(TransformSystem::TransformPropagate)
                     .after(VisibilitySystems::CheckVisibility)
                     .after(CameraUpdateSystem)
@@ -187,13 +193,11 @@ impl Plugin for PbrPlugin {
             .add_system(
                 update_directional_light_cascades
                     .in_set(SimulationLightSystems::UpdateDirectionalLightCascades)
-                    .in_set(CoreSet::PostUpdate)
                     .after(TransformSystem::TransformPropagate),
             )
             .add_system(
                 update_directional_light_frusta
                     .in_set(SimulationLightSystems::UpdateLightFrusta)
-                    .in_set(CoreSet::PostUpdate)
                     // This must run after CheckVisibility because it relies on ComputedVisibility::is_visible()
                     .after(VisibilitySystems::CheckVisibility)
                     .after(TransformSystem::TransformPropagate)
@@ -206,21 +210,18 @@ impl Plugin for PbrPlugin {
             .add_system(
                 update_point_light_frusta
                     .in_set(SimulationLightSystems::UpdateLightFrusta)
-                    .in_set(CoreSet::PostUpdate)
                     .after(TransformSystem::TransformPropagate)
                     .after(SimulationLightSystems::AssignLightsToClusters),
             )
             .add_system(
                 update_spot_light_frusta
                     .in_set(SimulationLightSystems::UpdateLightFrusta)
-                    .in_set(CoreSet::PostUpdate)
                     .after(TransformSystem::TransformPropagate)
                     .after(SimulationLightSystems::AssignLightsToClusters),
             )
             .add_system(
                 check_light_mesh_visibility
                     .in_set(SimulationLightSystems::CheckLightVisibility)
-                    .in_set(CoreSet::PostUpdate)
                     .after(TransformSystem::TransformPropagate)
                     .after(SimulationLightSystems::UpdateLightFrusta)
                     // NOTE: This MUST be scheduled AFTER the core renderer visibility check

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -209,57 +209,50 @@ impl Plugin for VisibilityPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         use VisibilitySystems::*;
 
-        app.add_system(
-            calculate_bounds
-                .in_set(CalculateBounds)
-                // The commands from this system must be applied before we compute culling frustra
-                .in_set(CoreSet::Update),
-        )
-        .add_system(
-            update_frusta::<OrthographicProjection>
-                .in_set(UpdateOrthographicFrusta)
-                .in_set(CoreSet::PostUpdate)
-                .after(camera_system::<OrthographicProjection>)
-                .after(TransformSystem::TransformPropagate)
-                // We assume that no camera will have more than one projection component,
-                // so these systems will run independently of one another.
-                // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                .ambiguous_with(update_frusta::<PerspectiveProjection>)
-                .ambiguous_with(update_frusta::<Projection>),
-        )
-        .add_system(
-            update_frusta::<PerspectiveProjection>
-                .in_set(UpdatePerspectiveFrusta)
-                .in_set(CoreSet::PostUpdate)
-                .after(camera_system::<PerspectiveProjection>)
-                .after(TransformSystem::TransformPropagate)
-                // We assume that no camera will have more than one projection component,
-                // so these systems will run independently of one another.
-                // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                .ambiguous_with(update_frusta::<Projection>),
-        )
-        .add_system(
-            update_frusta::<Projection>
-                .in_set(UpdateProjectionFrusta)
-                .in_set(CoreSet::PostUpdate)
-                .after(camera_system::<Projection>)
-                .after(TransformSystem::TransformPropagate),
-        )
-        .add_system(
-            visibility_propagate_system
-                .in_set(VisibilityPropagate)
-                .in_set(CoreSet::PostUpdate),
-        )
-        .add_system(
-            check_visibility
-                .in_set(CheckVisibility)
-                .in_set(CoreSet::PostUpdate)
-                .after(UpdateOrthographicFrusta)
-                .after(UpdatePerspectiveFrusta)
-                .after(UpdateProjectionFrusta)
-                .after(VisibilityPropagate)
-                .after(TransformSystem::TransformPropagate),
-        );
+        app.configure_set(CalculateBounds.in_set(CoreSet::Update))
+            .configure_set(UpdateOrthographicFrusta.in_set(CoreSet::PostUpdate))
+            .configure_set(UpdatePerspectiveFrusta.in_set(CoreSet::PostUpdate))
+            .configure_set(UpdateProjectionFrusta.in_set(CoreSet::PostUpdate))
+            .configure_set(CheckVisibility.in_set(CoreSet::PostUpdate))
+            .configure_set(VisibilityPropagate.in_set(CoreSet::PostUpdate))
+            .add_system(calculate_bounds.in_set(CalculateBounds))
+            .add_system(
+                update_frusta::<OrthographicProjection>
+                    .in_set(UpdateOrthographicFrusta)
+                    .after(camera_system::<OrthographicProjection>)
+                    .after(TransformSystem::TransformPropagate)
+                    // We assume that no camera will have more than one projection component,
+                    // so these systems will run independently of one another.
+                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
+                    .ambiguous_with(update_frusta::<PerspectiveProjection>)
+                    .ambiguous_with(update_frusta::<Projection>),
+            )
+            .add_system(
+                update_frusta::<PerspectiveProjection>
+                    .in_set(UpdatePerspectiveFrusta)
+                    .after(camera_system::<PerspectiveProjection>)
+                    .after(TransformSystem::TransformPropagate)
+                    // We assume that no camera will have more than one projection component,
+                    // so these systems will run independently of one another.
+                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
+                    .ambiguous_with(update_frusta::<Projection>),
+            )
+            .add_system(
+                update_frusta::<Projection>
+                    .in_set(CoreSet::PostUpdate)
+                    .after(camera_system::<Projection>)
+                    .after(TransformSystem::TransformPropagate),
+            )
+            .add_system(visibility_propagate_system.in_set(VisibilityPropagate))
+            .add_system(
+                check_visibility
+                    .in_set(CheckVisibility)
+                    .after(UpdateOrthographicFrusta)
+                    .after(UpdatePerspectiveFrusta)
+                    .after(UpdateProjectionFrusta)
+                    .after(VisibilityPropagate)
+                    .after(TransformSystem::TransformPropagate),
+            );
     }
 }
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -39,7 +39,8 @@ impl Plugin for TimePlugin {
             .register_type::<Time>()
             .register_type::<Stopwatch>()
             .init_resource::<FixedTime>()
-            .add_system(time_system.in_set(TimeSystem).in_set(CoreSet::First))
+            .configure_set(TimeSystem.in_set(CoreSet::First))
+            .add_system(time_system.in_set(TimeSystem))
             .add_system(run_fixed_update_schedule.in_set(CoreSet::FixedUpdate));
     }
 }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -98,25 +98,13 @@ impl Plugin for TransformPlugin {
             .register_type::<GlobalTransform>()
             .add_plugin(ValidParentCheckPlugin::<GlobalTransform>::default())
             // add transform systems to startup so the first update is "correct"
-            .add_startup_system(
-                sync_simple_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .in_set(StartupSet::PostStartup),
-            )
-            .add_startup_system(
-                propagate_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .in_set(StartupSet::PostStartup),
-            )
-            .add_system(
-                sync_simple_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .in_set(CoreSet::PostUpdate),
-            )
-            .add_system(
-                propagate_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .in_set(CoreSet::PostUpdate),
-            );
+            .configure_set(TransformSystem::TransformPropagate.in_set(CoreSet::PostUpdate))
+            .edit_schedule(CoreSchedule::Startup, |schedule| {
+                schedule.configure_set(TransformSystem::TransformPropagate.in_set(StartupSet::PostStartup));
+            })
+            .add_startup_system(sync_simple_transforms.in_set(TransformSystem::TransformPropagate))
+            .add_startup_system(propagate_transforms.in_set(TransformSystem::TransformPropagate))
+            .add_system(sync_simple_transforms.in_set(TransformSystem::TransformPropagate))
+            .add_system(propagate_transforms.in_set(TransformSystem::TransformPropagate));
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -101,12 +101,10 @@ impl Plugin for UiPlugin {
             .register_type::<UiImage>()
             .register_type::<Val>()
             .register_type::<widget::Button>()
-            .add_system(
-                ui_focus_system
-                    .in_set(UiSystem::Focus)
-                    .in_set(CoreSet::PreUpdate)
-                    .after(InputSystem),
-            )
+            .configure_set(UiSystem::Focus.in_set(CoreSet::PreUpdate))
+            .configure_set(UiSystem::Flex.in_set(CoreSet::PreUpdate))
+            .configure_set(UiSystem::Stack.in_set(CoreSet::PreUpdate))
+            .add_system(ui_focus_system.in_set(UiSystem::Focus).after(InputSystem))
             // add these systems to front because these must run before transform update systems
             .add_system(
                 widget::text_system
@@ -136,16 +134,11 @@ impl Plugin for UiPlugin {
             )
             .add_system(
                 flex_node_system
-                    .in_set(CoreSet::PostUpdate)
                     .in_set(UiSystem::Flex)
                     .before(TransformSystem::TransformPropagate)
                     .after(ModifiesWindows),
             )
-            .add_system(
-                ui_stack_system
-                    .in_set(UiSystem::Stack)
-                    .in_set(CoreSet::PostUpdate),
-            )
+            .add_system(ui_stack_system.in_set(UiSystem::Stack))
             .add_system(
                 update_clipping_system
                     .after(TransformSystem::TransformPropagate)

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -50,11 +50,8 @@ impl Plugin for WinitPlugin {
         app.init_non_send_resource::<WinitWindows>()
             .init_resource::<WinitSettings>()
             .set_runner(winit_runner)
-            .add_systems(
-                (changed_window, despawn_window)
-                    .in_set(ModifiesWindows)
-                    .in_set(CoreSet::PostUpdate),
-            );
+            .configure_set(ModifiesWindows.in_set(CoreSet::PostUpdate))
+            .add_systems((changed_window, despawn_window).in_set(ModifiesWindows));
 
         #[cfg(target_arch = "wasm32")]
         app.add_plugin(CanvasParentResizePlugin);

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -292,7 +292,11 @@ fn main() {
         .configure_set(MySet::BeforeRound.no_default_set().before(CoreSet::Update))
         .configure_set(MySet::AfterRound.no_default_set().after(CoreSet::Update))
         .add_system(new_round_system.in_set(MySet::BeforeRound))
-        .add_system(new_player_system.after(new_round_system).in_set(MySet::BeforeRound))
+        .add_system(
+            new_player_system
+                .after(new_round_system)
+                .in_set(MySet::BeforeRound),
+        )
         .add_system(exclusive_player_system.in_set(MySet::BeforeRound))
         .add_system(score_check_system.in_set(MySet::AfterRound))
         .add_system(


### PR DESCRIPTION
# Objective

A lot of times a system gets its own set to be referenced from somewhere else without making the function public:
`time_system in TimeSystem`
`time_system in CoreSet::Update`

It would be clearer, and easier for third party debug tools, if the hierarchy were like this:
`time_system in TimeSystem`
`TimeSystem in CoreSet::Update`

This should be equivalent but easier to work with.

## Solution
- replace
```rust
.add_system(system.in_set(MySet).in_set(CoreSet::Update))
```
with
```rust
.configure_set(MySet.in_set(CoreSet::Update))
.add_system(system.in_set(MySet)
```

---


**New Schedule**
![schedule_updated](https://user-images.githubusercontent.com/22177966/215112763-2d7e36dd-c860-4b7c-8d3a-5b0347d9e9e5.svg)
