### PR TITLE
add a system to run the enter schedule of the initial state

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -2,7 +2,10 @@ use crate::{CoreSchedule, CoreSet, Plugin, PluginGroup, StartupSet};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     prelude::*,
-    scheduling::{apply_state_transition, BoxedScheduleLabel, ScheduleLabel},
+    scheduling::{
+        apply_state_transition, common_conditions::run_once as run_once_condition,
+        run_enter_schedule, BoxedScheduleLabel, IntoSystemConfig, ScheduleLabel,
+    },
 };
 use bevy_utils::{tracing::debug, HashMap, HashSet};
 use std::fmt::Debug;
@@ -313,7 +316,14 @@ impl App {
     pub fn add_state<S: States>(&mut self) -> &mut Self {
         self.init_resource::<State<S>>();
         self.init_resource::<NextState<S>>();
-        self.add_system(apply_state_transition::<S>.in_set(CoreSet::StateTransitions));
+        self.add_systems(
+            (
+                run_enter_schedule::<S>.run_if(run_once_condition()),
+                apply_state_transition::<S>,
+            )
+                .chain()
+                .in_set(CoreSet::StateTransitions),
+        );
 
         let main_schedule = self.get_schedule_mut(CoreSchedule::Main).unwrap();
         for variant in S::variants() {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -301,9 +301,12 @@ impl App {
     }
 
     /// Adds [`State<S>`] and [`NextState<S>`] resources, [`OnEnter`] and [`OnExit`] schedules
-    /// for each state variant, and an instance of [`apply_state_transition::<S>`] in
-    /// [`CoreSet::StateTransitions`] so that transitions happen before [`CoreSet::Update`].
-    ///
+    /// for each state variant, an instance of [`apply_state_transition::<S>`] in 
+    /// [`CoreSet::StateTransitions`] so that transitions happen before [`CoreSet::Update`] and
+    /// a instance of [`run_enter_schedule::<S>`] in [`CoreSet::StateTransitions`] with a 
+    /// with a [`run_once`](`run_once_condition`) condition to run the on enter schedule of the 
+    /// initial state.
+    /// 
     /// This also adds an [`OnUpdate`] system set for each state variant,
     /// which run during [`CoreSet::StateTransitions`] after the transitions are applied.
     /// These systems sets only run if the [`State<S>`] resource matches their label.

--- a/crates/bevy_ecs/src/scheduling/condition.rs
+++ b/crates/bevy_ecs/src/scheduling/condition.rs
@@ -29,6 +29,20 @@ pub mod common_conditions {
     use crate::system::{Res, Resource};
 
     /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`
+    /// if the first time the condition is run and false every time after
+    pub fn run_once() -> impl FnMut() -> bool {
+        let mut has_run = false;
+        move || {
+            if !has_run {
+                has_run = true;
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`
     /// if the resource exists.
     pub fn resource_exists<T>() -> impl FnMut(Option<Res<T>>) -> bool
     where

--- a/crates/bevy_ecs/src/scheduling/state.rs
+++ b/crates/bevy_ecs/src/scheduling/state.rs
@@ -92,6 +92,11 @@ impl<S: States> NextState<S> {
     }
 }
 
+/// Run the enter schedule for the current state
+pub fn run_enter_schedule<S: States>(world: &mut World) {
+    world.run_schedule(OnEnter(world.resource::<State<S>>().0.clone()));
+}
+
 /// If a new state is queued in [`NextState<S>`], this system:
 /// - Takes the new state value from [`NextState<S>`] and updates [`State<S>`].
 /// - Runs the [`OnExit(exited_state)`] schedule.


### PR DESCRIPTION
# Objective

- This adds a second system for each state that runs once and runs the enter state for the initial state. Not sure if this makes sense or we should just modify apply_state_transitions.