### PR TITLE
cleanup executor traces

### DIFF
--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -179,9 +179,6 @@ impl Schedule {
     pub fn run(&mut self, world: &mut World) {
         world.check_change_ticks();
         self.initialize(world).unwrap();
-        // TODO: label
-        #[cfg(feature = "trace")]
-        let _span = info_span!("schedule").entered();
         self.executor.run(&mut self.executable, world);
     }
 
@@ -234,8 +231,6 @@ impl Schedule {
     /// before applying their buffers in a different world.
     pub fn apply_system_buffers(&mut self, world: &mut World) {
         for system in &mut self.executable.systems {
-            #[cfg(feature = "trace")]
-            let _apply_buffers_span = info_span!("apply_buffers", name = &*system.name()).entered();
             system.apply_buffers(world);
         }
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1958,6 +1958,9 @@ impl World {
             .remove_entry(label)
             .unwrap_or_else(|| panic!("The schedule with the label {label:?} was not found."));
 
+        // TODO: move this span to Schdule::run
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!("schedule", name = ?extracted_label).entered();
         schedule.run(self);
         self.resource_mut::<Schedules>()
             .insert(extracted_label, schedule);


### PR DESCRIPTION
# Objective

- Tracing spans were a little too noisy. Especially since trancing spans aren't quite free

## Solution

- Move run schedule into the world.run_schedule so the name of the schedule is available to the span. This should probably eventually be moved back, but this is a quick fix
- removed the apply_buffers span. Each system has it's own system_commands span that only gets logged when a system actually applies commands
- removed the check_conditions, check_access, and signal dependents spans. These are just too noisy and expensive to be doing for each system.

Before
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/2180432/215296035-707475a3-6ef6-4391-99d3-d82492bf8f5f.png">

After
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/2180432/215295921-e2759c09-c4f0-4027-8378-7b0b62a8fe8a.png">
