### PR TITLE
add a method on add to create a simple outer schedule

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -529,6 +529,20 @@ impl App {
         self
     }
 
+    /// adds a single threaded outer schedule to the [`App`] that just runs the main schedule
+    pub fn add_simple_outer_schedule(&mut self) -> &mut Self {
+        fn run_main_schedule(world: &mut World) {
+            world.run_schedule(CoreSchedule::Main);
+        }
+
+        self.edit_schedule(CoreSchedule::Outer, |schedule| {
+            schedule.set_executor_kind(bevy_ecs::scheduling::ExecutorKind::SingleThreaded);
+            schedule.add_system(run_main_schedule);
+        });
+
+        self
+    }
+
     /// Setup the application to manage events of type `T`.
     ///
     /// This is done by adding a [`Resource`] of type [`Events::<T>`],

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -71,9 +71,10 @@ impl CoreSchedule {
         world.run_schedule(CoreSchedule::Main);
     }
 
-    /// Initializes a schedule for [`CoreSchedule::Outer`] that contains the [`outer_loop`] system.
+    /// Initializes a single threaded schedule for [`CoreSchedule::Outer`] that contains the [`outer_loop`] system.
     pub fn outer_schedule() -> Schedule {
         let mut schedule = Schedule::new();
+        schedule.set_executor_kind(bevy_ecs::scheduling::ExecutorKind::SingleThreaded);
         schedule.add_system(Self::outer_loop);
         schedule
     }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -214,6 +214,7 @@ impl Plugin for RenderPlugin {
             let asset_server = app.world.resource::<AssetServer>().clone();
 
             let mut render_app = App::empty();
+            render_app.add_simple_outer_schedule();
             let mut render_schedule = RenderSet::base_schedule();
 
             // Prepare the schedule which extracts data from the main world to the render world
@@ -238,13 +239,7 @@ impl Plugin for RenderPlugin {
 
             render_schedule.add_system(World::clear_entities.in_set(RenderSet::Cleanup));
 
-            let mut outer_schedule = Schedule::new();
-            outer_schedule.add_system(|world: &mut World| {
-                world.run_schedule(CoreSchedule::Main);
-            });
-
             render_app
-                .add_schedule(CoreSchedule::Outer, outer_schedule)
                 .add_schedule(CoreSchedule::Main, render_schedule)
                 .init_resource::<render_graph::RenderGraph>()
                 .insert_resource(RenderInstance(instance))

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -2,7 +2,7 @@ use async_channel::{Receiver, Sender};
 
 use bevy_app::{App, AppLabel, CoreSchedule, Plugin, SubApp};
 use bevy_ecs::{
-    scheduling::{MainThreadExecutor, Schedule},
+    scheduling::MainThreadExecutor,
     system::Resource,
     world::{Mut, World},
 };
@@ -72,12 +72,8 @@ impl Plugin for PipelinedRenderingPlugin {
         app.insert_resource(MainThreadExecutor::new());
 
         let mut sub_app = App::empty();
+        sub_app.add_simple_outer_schedule();
         sub_app.init_schedule(CoreSchedule::Main);
-        let mut outer_schedule = Schedule::new();
-        outer_schedule.add_system(|world: &mut World| {
-            world.run_schedule(CoreSchedule::Main);
-        });
-        sub_app.add_schedule(CoreSchedule::Outer, outer_schedule);
         app.insert_sub_app(RenderExtractApp, SubApp::new(sub_app, update_rendering));
     }
 

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -23,10 +23,7 @@
 
 use crate::Time;
 use bevy_app::CoreSchedule;
-use bevy_ecs::{
-    system::Resource,
-    world::{Mut, World},
-};
+use bevy_ecs::{system::Resource, world::World};
 use bevy_utils::Duration;
 use thiserror::Error;
 


### PR DESCRIPTION
# Objective

- Add a method on app for creating an outer schedule that just runs the main schedule
- use it for the render and extract sub apps
- make the outer schedule for the main app single threaded