### PR TITLE
Stage yeet commands fixing

### DIFF
--- a/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
@@ -191,18 +191,6 @@ impl SystemExecutor for MultiThreadedExecutor {
                             self.rebuild_active_access();
                         }
                     }
-
-                    // SAFETY: all systems have completed
-                    let world = unsafe { &mut *world.get() };
-                    apply_system_buffers(&mut self.unapplied_systems, systems, world);
-
-                    debug_assert!(self.ready_systems.is_clear());
-                    debug_assert!(self.running_systems.is_clear());
-                    debug_assert!(self.unapplied_systems.is_clear());
-                    self.active_access.clear();
-                    self.evaluated_sets.clear();
-                    self.skipped_systems.clear();
-                    self.completed_systems.clear();
                 };
 
                 #[cfg(feature = "trace")]
@@ -212,6 +200,19 @@ impl SystemExecutor for MultiThreadedExecutor {
                 scope.spawn(executor);
             },
         );
+
+        // SAFETY: all systems have completed
+        let world = unsafe { &mut *world.get() };
+        // this is running on the executor thread when it should run on the scope's thread
+        apply_system_buffers(&mut self.unapplied_systems, systems, world);
+
+        debug_assert!(self.ready_systems.is_clear());
+        debug_assert!(self.running_systems.is_clear());
+        debug_assert!(self.unapplied_systems.is_clear());
+        self.active_access.clear();
+        self.evaluated_sets.clear();
+        self.skipped_systems.clear();
+        self.completed_systems.clear();
     }
 }
 

--- a/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
@@ -205,6 +205,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         let world = unsafe { &mut *world.get() };
         // this is running on the executor thread when it should run on the scope's thread
         apply_system_buffers(&mut self.unapplied_systems, systems, world);
+        self.unapplied_systems.clear();
 
         debug_assert!(self.ready_systems.is_clear());
         debug_assert!(self.running_systems.is_clear());
@@ -469,6 +470,7 @@ impl MultiThreadedExecutor {
         if is_apply_system_buffers(system) {
             // TODO: avoid allocation
             let mut unapplied_systems = self.unapplied_systems.clone();
+            self.unapplied_systems.clear();
             let task = async move {
                 #[cfg(feature = "trace")]
                 let system_guard = system_span.enter();
@@ -561,8 +563,6 @@ fn apply_system_buffers(
         let system = unsafe { &mut *systems[system_index].get() };
         system.apply_buffers(world);
     }
-
-    unapplied_systems.clear();
 }
 
 fn evaluate_and_fold_conditions(conditions: &mut [BoxedCondition], world: &World) -> bool {

--- a/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
@@ -201,9 +201,9 @@ impl SystemExecutor for MultiThreadedExecutor {
             },
         );
 
-        // SAFETY: all systems have completed
+        // SAFETY: all systems have completed, and so no outstanding accesses remain
         let world = unsafe { &mut *world.get() };
-        // this is running on the executor thread when it should run on the scope's thread
+        // Commands should be applied while on the scope's thread, not the executor's thread
         apply_system_buffers(&mut self.unapplied_systems, systems, world);
         self.unapplied_systems.clear();
 

--- a/crates/bevy_ecs/src/scheduling/executor/simple.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/simple.rs
@@ -78,8 +78,6 @@ impl SystemExecutor for SimpleExecutor {
             #[cfg(feature = "trace")]
             system_span.exit();
 
-            #[cfg(feature = "trace")]
-            let _apply_buffers_span = info_span!("apply_buffers", name = &*name).entered();
             system.apply_buffers(world);
         }
 

--- a/crates/bevy_ecs/src/scheduling/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/single_threaded.rs
@@ -114,8 +114,6 @@ impl SingleThreadedExecutor {
     fn apply_system_buffers(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
         for system_index in self.unapplied_systems.ones() {
             let system = &mut schedule.systems[system_index];
-            #[cfg(feature = "trace")]
-            let _apply_buffers_span = info_span!("apply_buffers", name = &*system.name()).entered();
             system.apply_buffers(world);
         }
 


### PR DESCRIPTION
# Objective

Fix a few bugs around command application

1. final command application is running on executor thread instead of schedule thread
2. unapplied systems buffer was never being cleared

## Solution

1. move the final command application outside of executor and outside of the scope
2. clear the unapplied_systems buffer on self instead of the cloned one.
3.  snuck removes some more spans into this pr. These spans aren't needed as they duplicate ones on Commands::apply