### PR TITLE
Stage yeet skip commands

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -108,7 +108,7 @@ impl Debug for App {
 /// struct ExampleApp;
 ///
 /// let mut app = App::new();
-/// 
+///
 /// // initialize the main app with a value of 0;
 /// app.insert_resource(Val(10));
 ///
@@ -117,7 +117,7 @@ impl Debug for App {
 /// // add an outer schedule that runs the main schedule
 /// sub_app.add_simple_outer_schedule();
 /// sub_app.insert_resource(Val(100));
-/// 
+///
 /// // initialize main schedule
 /// sub_app.init_schedule(CoreSchedule::Main);
 /// sub_app.add_system(|counter: Res<Val>| {
@@ -125,7 +125,7 @@ impl Debug for App {
 ///     // we see that value instead of 100
 ///     assert_eq!(counter.0, 10);
 /// });
-/// 
+///
 /// // add the sub_app to the app
 /// app.insert_sub_app(ExampleApp, SubApp::new(sub_app, |main_world, sub_app| {
 ///     // extract the value from the main app to the sub app

--- a/crates/bevy_ecs/src/scheduling/executor/mod.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/mod.rs
@@ -19,7 +19,7 @@ pub(super) trait SystemExecutor: Send + Sync {
     fn kind(&self) -> ExecutorKind;
     fn init(&mut self, schedule: &SystemSchedule);
     fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World);
-    fn skip_final_apply_buffers(&mut self);
+    fn set_apply_final_buffers(&mut self, value: bool);
 }
 
 /// Specifies how a [`Schedule`](super::Schedule) will be run.

--- a/crates/bevy_ecs/src/scheduling/executor/mod.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/mod.rs
@@ -19,6 +19,7 @@ pub(super) trait SystemExecutor: Send + Sync {
     fn kind(&self) -> ExecutorKind;
     fn init(&mut self, schedule: &SystemSchedule);
     fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World);
+    fn skip_final_apply_buffers(&mut self);
 }
 
 /// Specifies how a [`Schedule`](super::Schedule) will be run.

--- a/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/multi_threaded.rs
@@ -96,6 +96,8 @@ pub struct MultiThreadedExecutor {
     completed_systems: FixedBitSet,
     /// Systems that have run but have not had their buffers applied.
     unapplied_systems: FixedBitSet,
+    /// Setting when true applies system buffers after all systems have run
+    apply_system_buffers_at_end: bool,
 }
 
 impl Default for MultiThreadedExecutor {
@@ -107,6 +109,10 @@ impl Default for MultiThreadedExecutor {
 impl SystemExecutor for MultiThreadedExecutor {
     fn kind(&self) -> ExecutorKind {
         ExecutorKind::MultiThreaded
+    }
+
+    fn skip_final_apply_buffers(&mut self) {
+        self.apply_system_buffers_at_end = false;
     }
 
     fn init(&mut self, schedule: &SystemSchedule) {
@@ -201,15 +207,17 @@ impl SystemExecutor for MultiThreadedExecutor {
             },
         );
 
-        // SAFETY: all systems have completed, and so no outstanding accesses remain
-        let world = unsafe { &mut *world.get() };
-        // Commands should be applied while on the scope's thread, not the executor's thread
-        apply_system_buffers(&mut self.unapplied_systems, systems, world);
-        self.unapplied_systems.clear();
+        if self.apply_system_buffers_at_end {
+            // SAFETY: all systems have completed
+            let world = unsafe { &mut *world.get() };
+            // this is running on the executor thread when it should run on the scope's thread
+            apply_system_buffers(&mut self.unapplied_systems, systems, world);
+            self.unapplied_systems.clear();
+            debug_assert!(self.unapplied_systems.is_clear());
+        }
 
         debug_assert!(self.ready_systems.is_clear());
         debug_assert!(self.running_systems.is_clear());
-        debug_assert!(self.unapplied_systems.is_clear());
         self.active_access.clear();
         self.evaluated_sets.clear();
         self.skipped_systems.clear();
@@ -237,6 +245,7 @@ impl MultiThreadedExecutor {
             skipped_systems: FixedBitSet::new(),
             completed_systems: FixedBitSet::new(),
             unapplied_systems: FixedBitSet::new(),
+            apply_system_buffers_at_end: true,
         }
     }
 

--- a/crates/bevy_ecs/src/scheduling/executor/simple.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/simple.rs
@@ -22,7 +22,7 @@ impl SystemExecutor for SimpleExecutor {
         ExecutorKind::Simple
     }
 
-    fn skip_final_apply_buffers(&mut self) {
+    fn set_apply_final_buffers(&mut self, _: bool) {
         // do nothing. simple executor does not do a final sync
     }
 

--- a/crates/bevy_ecs/src/scheduling/executor/simple.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/simple.rs
@@ -22,6 +22,10 @@ impl SystemExecutor for SimpleExecutor {
         ExecutorKind::Simple
     }
 
+    fn skip_final_apply_buffers(&mut self) {
+        // do nothing. simple executor does not do a final sync
+    }
+
     fn init(&mut self, schedule: &SystemSchedule) {
         let sys_count = schedule.system_ids.len();
         let set_count = schedule.set_ids.len();

--- a/crates/bevy_ecs/src/scheduling/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/single_threaded.rs
@@ -21,11 +21,17 @@ pub struct SingleThreadedExecutor {
     completed_systems: FixedBitSet,
     /// Systems that have run but have not had their buffers applied.
     unapplied_systems: FixedBitSet,
+    /// Setting when true applies system buffers after all systems have run
+    apply_system_buffers_at_end: bool,
 }
 
 impl SystemExecutor for SingleThreadedExecutor {
     fn kind(&self) -> ExecutorKind {
         ExecutorKind::SingleThreaded
+    }
+
+    fn skip_final_apply_buffers(&mut self) {
+        self.apply_system_buffers_at_end = false;
     }
 
     fn init(&mut self, schedule: &SystemSchedule) {
@@ -96,7 +102,9 @@ impl SystemExecutor for SingleThreadedExecutor {
             }
         }
 
-        self.apply_system_buffers(schedule, world);
+        if self.apply_system_buffers_at_end {
+            self.apply_system_buffers(schedule, world);
+        }
         self.evaluated_sets.clear();
         self.completed_systems.clear();
     }
@@ -108,6 +116,7 @@ impl SingleThreadedExecutor {
             evaluated_sets: FixedBitSet::new(),
             completed_systems: FixedBitSet::new(),
             unapplied_systems: FixedBitSet::new(),
+            apply_system_buffers_at_end: true,
         }
     }
 

--- a/crates/bevy_ecs/src/scheduling/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/scheduling/executor/single_threaded.rs
@@ -22,7 +22,7 @@ pub struct SingleThreadedExecutor {
     /// Systems that have run but have not had their buffers applied.
     unapplied_systems: FixedBitSet,
     /// Setting when true applies system buffers after all systems have run
-    apply_system_buffers_at_end: bool,
+    apply_final_buffers: bool,
 }
 
 impl SystemExecutor for SingleThreadedExecutor {
@@ -30,8 +30,8 @@ impl SystemExecutor for SingleThreadedExecutor {
         ExecutorKind::SingleThreaded
     }
 
-    fn skip_final_apply_buffers(&mut self) {
-        self.apply_system_buffers_at_end = false;
+    fn set_apply_final_buffers(&mut self, apply_final_buffers: bool) {
+        self.apply_final_buffers = apply_final_buffers;
     }
 
     fn init(&mut self, schedule: &SystemSchedule) {
@@ -102,7 +102,7 @@ impl SystemExecutor for SingleThreadedExecutor {
             }
         }
 
-        if self.apply_system_buffers_at_end {
+        if self.apply_final_buffers {
             self.apply_system_buffers(schedule, world);
         }
         self.evaluated_sets.clear();
@@ -116,7 +116,7 @@ impl SingleThreadedExecutor {
             evaluated_sets: FixedBitSet::new(),
             completed_systems: FixedBitSet::new(),
             unapplied_systems: FixedBitSet::new(),
-            apply_system_buffers_at_end: true,
+            apply_final_buffers: true,
         }
     }
 

--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -175,6 +175,14 @@ impl Schedule {
         self
     }
 
+    /// Normally the schedule applies buffers one final time after all systems have run.
+    /// Setting this tells the schedule to skip the final sync. Any apply_systems_buffers
+    /// systems that have been added to the schedule will still run.
+    pub fn skip_final_apply_buffers(&mut self) -> &mut Self {
+        self.executor.skip_final_apply_buffers();
+        self
+    }
+
     /// Runs all systems in this schedule on the `world`, using its current execution strategy.
     pub fn run(&mut self, world: &mut World) {
         world.check_change_ticks();

--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -175,11 +175,12 @@ impl Schedule {
         self
     }
 
-    /// Normally the schedule applies buffers one final time after all systems have run.
-    /// Setting this tells the schedule to skip the final sync. Any `apply_systems_buffers`
-    /// systems that have been added to the schedule will still run.
-    pub fn skip_final_apply_buffers(&mut self) -> &mut Self {
-        self.executor.skip_final_apply_buffers();
+    /// Set whether the schedule applies buffers on final time or not. This is a catchall
+    /// incase a system uses commands but was not explicitly ordered after a 
+    /// [`apply_system_buffers`](crate::prelude::apply_system_buffers). By default this
+    /// setting is true, but may be disabled if needed.
+    pub fn set_apply_final_buffers(&mut self, apply_final_buffers: bool) -> &mut Self {
+        self.executor.set_apply_final_buffers(apply_final_buffers);
         self
     }
 

--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -176,7 +176,7 @@ impl Schedule {
     }
 
     /// Normally the schedule applies buffers one final time after all systems have run.
-    /// Setting this tells the schedule to skip the final sync. Any apply_systems_buffers
+    /// Setting this tells the schedule to skip the final sync. Any `apply_systems_buffers`
     /// systems that have been added to the schedule will still run.
     pub fn skip_final_apply_buffers(&mut self) -> &mut Self {
         self.executor.skip_final_apply_buffers();

--- a/crates/bevy_ecs/src/scheduling/schedule.rs
+++ b/crates/bevy_ecs/src/scheduling/schedule.rs
@@ -176,7 +176,7 @@ impl Schedule {
     }
 
     /// Set whether the schedule applies buffers on final time or not. This is a catchall
-    /// incase a system uses commands but was not explicitly ordered after a 
+    /// incase a system uses commands but was not explicitly ordered after a
     /// [`apply_system_buffers`](crate::prelude::apply_system_buffers). By default this
     /// setting is true, but may be disabled if needed.
     pub fn set_apply_final_buffers(&mut self, apply_final_buffers: bool) -> &mut Self {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -220,7 +220,7 @@ impl Plugin for RenderPlugin {
             // Prepare the schedule which extracts data from the main world to the render world
             render_app.edit_schedule(ExtractSchedule, |schedule| {
                 schedule
-                    .skip_final_apply_buffers()
+                    .set_apply_final_buffers(false)
                     .add_system(PipelineCache::extract_shaders);
             });
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -218,9 +218,11 @@ impl Plugin for RenderPlugin {
             let mut render_schedule = RenderSet::base_schedule();
 
             // Prepare the schedule which extracts data from the main world to the render world
-            render_app
-                .init_schedule(ExtractSchedule)
-                .add_system_to_schedule(ExtractSchedule, PipelineCache::extract_shaders);
+            render_app.edit_schedule(ExtractSchedule, |schedule| {
+                schedule
+                    .skip_final_apply_buffers()
+                    .add_system(PipelineCache::extract_shaders);
+            });
 
             // Get the ComponentId for MainWorld. This does technically 'waste' a `WorldId`, but that's probably fine
             render_app.init_resource::<MainWorld>();


### PR DESCRIPTION
# Objective

- There is a forced sync at the end of every schedule. This is for users in case they forget to add a sync to their custom schedules. The extract schedule want to delay this sync to run on the render thread instead of the main thread. So we need to add the ability to skip this sync.