### PR TITLE
fix game menu example

### DIFF
--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -288,7 +288,7 @@ mod menu {
                 )
                 // Systems to handle the display settings screen
                 .add_system_to_schedule(
-                    OnExit(MenuState::SettingsDisplay),
+                    OnEnter(MenuState::SettingsDisplay),
                     display_settings_menu_setup,
                 )
                 .add_system(setting_button::<DisplayQuality>.on_update(MenuState::SettingsDisplay))
@@ -314,11 +314,11 @@ mod menu {
     // State used for the current menu screen
     #[derive(Clone, Copy, Default, Eq, PartialEq, Debug, Hash)]
     enum MenuState {
-        #[default]
         Main,
         Settings,
         SettingsDisplay,
         SettingsSound,
+        #[default]
         Disabled,
     }
 


### PR DESCRIPTION
# Objective

- fix the game menu example. Just some small mis-migrations.
- There is a bit of weirdness where I see a smaller red menu when transitioning away from the splash screen, but I confirmed that that exists on main too.