### PR TITLE
More example tidying

### DIFF
--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -1,6 +1,6 @@
 //! This example demonstrates how to use the `Camera::viewport_to_world` method.
 
-use bevy::{math::Direction3d, prelude::*};
+use bevy::{math::Dir3, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -143,7 +143,7 @@ fn setup(
             intensity: 800.0,
             radius: 0.125,
             shadows_enabled: true,
-            color: sphere_color.into(),
+            color: sphere_color,
             ..default()
         },
         transform: sphere_pos,

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -55,7 +55,7 @@ fn setup(
         mesh: meshes.add(Cuboid::new(5.0, 0.15, 5.0)),
         transform,
         material: materials.add(StandardMaterial {
-            base_color: Color::from(INDIGO),
+            base_color: INDIGO.into(),
             perceptual_roughness: 1.0,
             ..default()
         }),
@@ -68,7 +68,7 @@ fn setup(
         mesh: meshes.add(Cuboid::new(5.0, 0.15, 5.0)),
         transform,
         material: materials.add(StandardMaterial {
-            base_color: Color::from(INDIGO),
+            base_color: INDIGO.into(),
             perceptual_roughness: 1.0,
             ..default()
         }),

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -74,12 +74,12 @@ fn setup(
     let sphere_mesh = meshes.add(Sphere::new(0.05).mesh().uv(32, 18));
     let sphere_mesh_direction = meshes.add(Sphere::new(0.1).mesh().uv(32, 18));
     let red_emissive = materials.add(StandardMaterial {
-        base_color: Color::from(RED),
+        base_color: RED.into(),
         emissive: Color::linear_rgba(100.0, 0.0, 0.0, 0.0),
         ..default()
     });
     let maroon_emissive = materials.add(StandardMaterial {
-        base_color: Color::from(MAROON),
+        base_color: MAROON.into(),
         emissive: Color::linear_rgba(50.0, 0.0, 0.0, 0.0),
         ..default()
     });

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -183,7 +183,7 @@ fn setup(
         PbrBundle {
             mesh: icosphere_mesh.clone(),
             material: materials.add(StandardMaterial {
-                base_color: Color::from(RED),
+                base_color: RED.into(),
                 specular_transmission: 0.9,
                 diffuse_transmission: 1.0,
                 thickness: 1.8,
@@ -206,7 +206,7 @@ fn setup(
         PbrBundle {
             mesh: icosphere_mesh.clone(),
             material: materials.add(StandardMaterial {
-                base_color: Color::from(GREEN),
+                base_color: GREEN.into(),
                 specular_transmission: 0.9,
                 diffuse_transmission: 1.0,
                 thickness: 1.8,
@@ -229,7 +229,7 @@ fn setup(
         PbrBundle {
             mesh: icosphere_mesh,
             material: materials.add(StandardMaterial {
-                base_color: Color::from(BLUE),
+                base_color: BLUE.into(),
                 specular_transmission: 0.9,
                 diffuse_transmission: 1.0,
                 thickness: 1.8,

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -95,7 +95,7 @@ fn generate_bodies(
                     transform: Transform::from_scale(Vec3::splat(star_radius)),
                     mesh: meshes.add(Sphere::new(1.0).mesh().ico(5).unwrap()),
                     material: materials.add(StandardMaterial {
-                        base_color: Color::from(ORANGE_RED),
+                        base_color: ORANGE_RED.into(),
                         emissive: (LinearRgba::from(ORANGE_RED) * 18.).into(),
                         ..default()
                     }),

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -221,7 +221,7 @@ fn select(
     transform.translation.z = 100.0;
 
     text.sections[1].value.clone_from(&contributor.name);
-    text.sections[1].style.color = sprite.color.into();
+    text.sections[1].style.color = sprite.color;
 }
 
 /// Change the modulate color to the "deselected" color and push

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -29,7 +29,7 @@ fn setup(
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: materials.add(ExtendedMaterial {
             base: StandardMaterial {
-                base_color: Color::from(RED),
+                base_color: RED.into(),
                 // can be used in forward or deferred mode.
                 opaque_render_method: OpaqueRendererMethod::Auto,
                 // in deferred mode, only the PbrInput can be modified (uvs, color and other material properties),

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -62,7 +62,7 @@ fn setup(
 
     let mesh = meshes.add(Cuboid::default());
     let material = materials.add(StandardMaterial {
-        base_color: Color::from(PINK),
+        base_color: PINK.into(),
         ..default()
     });
 

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -127,7 +127,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                     "",
                     TextStyle {
                         font_size,
-                        color: virtual_color.into(),
+                        color: virtual_color,
                         ..default()
                     },
                 )


### PR DESCRIPTION
- I missed the `Dir3` rename in conflict resolution for the previous PR, breaking that example.
- Fixed up remaining clippy unnecessary `.into` lints
- Fixed remaining spots where `Color::from` was used for `base_color`. I **think** that fixes all the cases where the type can actually be inferred.
